### PR TITLE
Allows setting headers when following links and making HTTP requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: elixir
 
 elixir:
-  - 1.1
   - 1.2
 
 otp_release:

--- a/lib/exhal.ex
+++ b/lib/exhal.ex
@@ -14,7 +14,7 @@ defmodule ExHal do
   ...>   }
   ...> }
   ...> |)
-  %ExHal.Document{links: %{"profile" => [%ExHal.Link{name: nil, rel: "profile", target: nil,
+  %ExHal.Document{headers: [], links: %{"profile" => [%ExHal.Link{name: nil, rel: "profile", target: nil,
                 href: "http://example.com/normal", templated: false},
                %ExHal.Link{name: nil, rel: "profile", target: nil, href: "http://example.com/special",
                 templated: false}],
@@ -64,6 +64,9 @@ defmodule ExHal do
   ExHal.follow_links(doc, "profile")
   [{:ok, %ExHal.Document{...}}, {:ok, %ExHal.Document{...}}]
 
+  ExHal.follow_links(doc, "profile", [], "Content-Type": "application/vnd.custom.json+type")
+  [{:ok, %ExHal.Document{...}}, {:ok, %ExHal.Document{...}}]
+
   ExHal.post(doc, "self", ~s|
   ...> { "name": "http://example.com/new-thing",
   ...>   "_links": {
@@ -72,6 +75,7 @@ defmodule ExHal do
   ...> }
   ...> |)
   {:ok, %ExHal.Document{...}}
+
   ```
   """
 
@@ -82,10 +86,9 @@ defmodule ExHal do
   @doc """
   Returns a new `%ExHal.Document` representing the HAL document provided.
   """
-  def parse(hal_str) do
+  def parse(hal_str, opts \\ %{}) do
     parsed = Poison.Parser.parse!(hal_str)
-
-    Document.from_parsed_hal(parsed)
+    Document.from_parsed_hal(parsed, opts)
   end
 
   @doc """
@@ -94,13 +97,15 @@ defmodule ExHal do
   Returns `{:ok,    %ExHal.Document{...}}` if request is an error
           `{:error, %ExHal.Error{...}}` if not
   """
-  def follow_link(a_doc, name, opts \\ %{pick_volunteer: false, tmpl_vars: %{}}) do
-    pick_volunteer? = Dict.get opts, :pick_volunteer, false
-    tmpl_vars = Dict.get opts, :tmpl_vars, %{}
+  def follow_link(a_doc, name, opts \\ %{tmpl_vars: %{}, pick_volunteer: false}, headers \\ []) do
+    opts = Map.new(opts)
+
+    pick_volunteer? = Map.get opts, :pick_volunteer, false
+    tmpl_vars       = Map.get opts, :tmpl_vars, %{}
 
     case figure_link(a_doc, name, pick_volunteer?) do
       {:error, e} -> {:error, e}
-      {:ok, link} -> Link.follow(link, tmpl_vars)
+      {:ok, link} -> Link.follow(link, tmpl_vars, headers)
     end
 
   end
@@ -110,13 +115,13 @@ defmodule ExHal do
 
   Returns `[{:ok, %ExHal.Document{...}}, {:error, %ExHal.Error{...}, ...]`
   """
-  def follow_links(a_doc, name, opts \\ %{tmpl_vars: %{}}) do
-    tmpl_vars = Dict.get opts, :tmpl_vars, %{}
+  def follow_links(a_doc, name, opts \\ %{tmpl_vars: %{}}, headers \\ []) do
+    opts      = Map.new(opts)
+    tmpl_vars = Map.get opts, :tmpl_vars, %{}
 
     case get_links_lazy(a_doc, name, fn -> :missing end) do
       :missing -> {:error, %Error{reason: "no such link: #{name}"}}
-
-      links    -> Enum.map(links, fn link -> Link.follow(link, tmpl_vars) end)
+      links    -> Enum.map(links, fn link -> Link.follow(link, tmpl_vars, headers) end)
     end
 
   end
@@ -163,7 +168,7 @@ defmodule ExHal do
           result of `default_fun` otherwise
   """
   def get_property_lazy(a_doc, prop_name, default_fun) do
-    Dict.get_lazy(a_doc.properties, prop_name, default_fun)
+    Map.get_lazy(a_doc.properties, prop_name, default_fun)
   end
 
   @doc """
@@ -171,7 +176,7 @@ defmodule ExHal do
           result of `default_fun` otherwise
   """
   def get_links_lazy(a_doc, link_name, default_fun) do
-    Dict.get_lazy(a_doc.links, link_name, default_fun)
+    Map.get_lazy(a_doc.links, link_name, default_fun)
   end
 
   @doc """

--- a/lib/exhal.ex
+++ b/lib/exhal.ex
@@ -64,7 +64,7 @@ defmodule ExHal do
   ExHal.follow_links(doc, "profile")
   [{:ok, %ExHal.Document{...}}, {:ok, %ExHal.Document{...}}]
 
-  ExHal.follow_links(doc, "profile", [], "Content-Type": "application/vnd.custom.json+type")
+  ExHal.follow_links(doc, "profile", headers: ["Content-Type": "application/vnd.custom.json+type"])
   [{:ok, %ExHal.Document{...}}, {:ok, %ExHal.Document{...}}]
 
   ExHal.post(doc, "self", ~s|
@@ -97,15 +97,13 @@ defmodule ExHal do
   Returns `{:ok,    %ExHal.Document{...}}` if request is an error
           `{:error, %ExHal.Error{...}}` if not
   """
-  def follow_link(a_doc, name, opts \\ %{tmpl_vars: %{}, pick_volunteer: false}, headers \\ []) do
+  def follow_link(a_doc, name, opts \\ %{tmpl_vars: %{}, pick_volunteer: false, headers: []}) do
     opts = Map.new(opts)
-
     pick_volunteer? = Map.get opts, :pick_volunteer, false
-    tmpl_vars       = Map.get opts, :tmpl_vars, %{}
 
     case figure_link(a_doc, name, pick_volunteer?) do
       {:error, e} -> {:error, e}
-      {:ok, link} -> Link.follow(link, tmpl_vars, headers)
+      {:ok, link} -> Link.follow(link, opts)
     end
 
   end
@@ -115,13 +113,12 @@ defmodule ExHal do
 
   Returns `[{:ok, %ExHal.Document{...}}, {:error, %ExHal.Error{...}, ...]`
   """
-  def follow_links(a_doc, name, opts \\ %{tmpl_vars: %{}}, headers \\ []) do
-    opts      = Map.new(opts)
-    tmpl_vars = Map.get opts, :tmpl_vars, %{}
+  def follow_links(a_doc, name, opts \\ %{tmpl_vars: %{}, headers: []}) do
+    opts = Map.new(opts)
 
     case get_links_lazy(a_doc, name, fn -> :missing end) do
       :missing -> {:error, %Error{reason: "no such link: #{name}"}}
-      links    -> Enum.map(links, fn link -> Link.follow(link, tmpl_vars, headers) end)
+      links    -> Enum.map(links, fn link -> Link.follow(link, opts) end)
     end
 
   end

--- a/lib/exhal/link.ex
+++ b/lib/exhal/link.ex
@@ -52,12 +52,14 @@ defmodule ExHal.Link do
   Returns `{:ok, %ExHal.Document{}}`    - representation of the target of the specifyed link
           `{:error, %ExHal.Document{}}` - non-2XX responses that have a HAL body
   """
-  def follow(link, vars \\ %{}) do
+  def follow(link, vars \\ %{}, headers \\ []) do
+    headers = Keyword.new(headers)
+
     case link do
       %{target: (t = %Document{})} -> {:ok, t}
 
       _ -> with_url link, vars, fn url ->
-          extract_return HTTPoison.get(url, [], follow_redirect: true)
+          extract_return HTTPoison.get(url, headers, follow_redirect: true)
         end
     end
   end
@@ -65,9 +67,11 @@ defmodule ExHal.Link do
   @doc """
   Makes a POST request against the target of the link.
   """
-  def post(link, body) do
+  def post(link, body, headers \\ []) do
+    headers = Keyword.new(headers)
+
     with_url link, fn url ->
-      extract_return HTTPoison.post(url, body, [], follow_redirect: true)
+      extract_return HTTPoison.post(url, body, headers, follow_redirect: true)
     end
   end
 
@@ -102,14 +106,14 @@ defmodule ExHal.Link do
                    [base]    -> {nil,base}
                  end
 
-    case Dict.fetch(namespaces, ns) do
+    case Map.fetch(namespaces, ns) do
       {:ok, tmpl} -> [rel, UriTemplate.expand(tmpl, rel: base)]
       :error      -> [rel]
     end
   end
 
   defp extract_doc(resp) do
-    doc = ExHal.parse(resp.body)
+    doc  = ExHal.parse(resp.body, headers: resp.headers)
     code = resp.status_code
 
     cond do

--- a/lib/exhal/link.ex
+++ b/lib/exhal/link.ex
@@ -52,13 +52,15 @@ defmodule ExHal.Link do
   Returns `{:ok, %ExHal.Document{}}`    - representation of the target of the specifyed link
           `{:error, %ExHal.Document{}}` - non-2XX responses that have a HAL body
   """
-  def follow(link, vars \\ %{}, headers \\ []) do
-    headers = Keyword.new(headers)
+  def follow(link, opts \\ %{}) do
+    opts      = Map.new(opts)
+    tmpl_vars = Map.get opts, :tmpl_vars, %{}
+    headers   = Map.get(opts, :headers, []) |> Keyword.new
 
     case link do
       %{target: (t = %Document{})} -> {:ok, t}
 
-      _ -> with_url link, vars, fn url ->
+      _ -> with_url link, tmpl_vars, fn url ->
           extract_return HTTPoison.get(url, headers, follow_redirect: true)
         end
     end
@@ -67,8 +69,9 @@ defmodule ExHal.Link do
   @doc """
   Makes a POST request against the target of the link.
   """
-  def post(link, body, headers \\ []) do
-    headers = Keyword.new(headers)
+  def post(link, body, opts \\ %{headers: []}) do
+    vars    = Map.new(opts)
+    headers = Map.get(opts, :headers, []) |> Keyword.new
 
     with_url link, fn url ->
       extract_return HTTPoison.post(url, body, headers, follow_redirect: true)

--- a/mix.exs
+++ b/mix.exs
@@ -6,26 +6,18 @@ defmodule ExHal.Mixfile do
      description: "Use HAL APIs with ease",
      version: "2.1.0",
      elixir: "~> 1.0",
+
+     test_coverage: [tool: ExCoveralls],
+     preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test],
+
      deps: deps,
      package: package]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type `mix help compile.app` for more information
   def application do
     [applications: [:logger]]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type `mix help deps` for more examples and options
   defp deps do
     [
       {:poison, "~>2.0"},
@@ -35,7 +27,8 @@ defmodule ExHal.Mixfile do
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
 
-      {:exvcr, "~> 0.7", only: :test}
+      {:exvcr, "~> 0.7", only: :test},
+      {:excoveralls, "~> 0.4", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,7 @@
   "earmark": {:hex, :earmark, "0.2.1"},
   "ex_doc": {:hex, :ex_doc, "0.11.4"},
   "exactor": {:hex, :exactor, "2.2.0"},
+  "excoveralls": {:hex, :excoveralls, "0.4.6"},
   "exjsx": {:hex, :exjsx, "3.2.0"},
   "exvcr": {:hex, :exvcr, "0.7.1"},
   "hackney": {:hex, :hackney, "1.4.8"},

--- a/test/exhal/link_test.exs
+++ b/test/exhal/link_test.exs
@@ -76,7 +76,6 @@ defmodule ExHal.LinkTest do
     test ".follow w/ normal link" do
       stub_request "http://example.com/", fn ->
         assert {:ok, (target = %Document{})} = Link.follow(ExHal.LinkTest.normal_link)
-
         assert {:ok, "http://example.com/"} = ExHal.url(target)
       end
     end
@@ -85,8 +84,7 @@ defmodule ExHal.LinkTest do
       stub_request "http://example.com/?q=test", fn ->
         link = ExHal.LinkTest.templated_link("http://example.com/{?q}")
 
-        assert {:ok, (target = %Document{})} = Link.follow(link, q: "test")
-
+        assert {:ok, (target = %Document{})} = Link.follow(link, tmpl_vars: [q: "test"])
         assert {:ok, "http://example.com/?q=test"} = ExHal.url(target)
       end
     end
@@ -94,7 +92,6 @@ defmodule ExHal.LinkTest do
     test ".follow w/ embedded link" do
       stub_request "http://example.com/embedded", fn ->
         assert {:ok, (target = %Document{})} = Link.follow(ExHal.LinkTest.embedded_link)
-
         assert {:ok, "http://example.com/embedded"} = ExHal.url(target)
       end
     end
@@ -105,7 +102,6 @@ defmodule ExHal.LinkTest do
 
       stub_post_request link, [resp: new_thing_hal], fn ->
         assert {:ok, (target = %Document{})} = Link.post(link, new_thing_hal)
-
         assert {:ok, "http://example.com/new-thing"} = ExHal.url(target)
       end
     end

--- a/test/exhal/link_test.exs
+++ b/test/exhal/link_test.exs
@@ -1,6 +1,6 @@
 defmodule ExHal.LinkTest do
   use ExUnit.Case, async: true
-#  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
   alias ExHal.Link, as: Link
   alias ExHal.Document, as: Document
@@ -72,10 +72,6 @@ defmodule ExHal.LinkTest do
     use ExUnit.Case, async: false
     use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
-    setup_all do
-      ExVCR.Config.cassette_library_dir(__DIR__, __DIR__)
-      :ok
-    end
 
     test ".follow w/ normal link" do
       stub_request "http://example.com/", fn ->
@@ -97,8 +93,7 @@ defmodule ExHal.LinkTest do
 
     test ".follow w/ embedded link" do
       stub_request "http://example.com/embedded", fn ->
-        assert {:ok, (target = %Document{})} = Link.follow(ExHal.LinkTest.embedded_link,
-                                                           q: "test")
+        assert {:ok, (target = %Document{})} = Link.follow(ExHal.LinkTest.embedded_link)
 
         assert {:ok, "http://example.com/embedded"} = ExHal.url(target)
       end
@@ -133,7 +128,9 @@ defmodule ExHal.LinkTest do
 
     def stub_post_request(link, opts \\ %{}, block) do
       {:ok, url} = Link.target_url(link)
-      resp = Dict.get opts, :resp, fn (_) -> hal_str(url) end
+
+      opts = Map.new(opts)
+      resp = Map.get opts, :resp, fn (_) -> hal_str(url) end
 
       use_cassette :stub, [url: url, method: "post", request_body: resp, body: resp, status_code: 201] do
         block.()

--- a/test/exhal_test.exs
+++ b/test/exhal_test.exs
@@ -153,7 +153,7 @@ defmodule ExHalFacts do
     test ".follow_link w/ templated link" do
       stub_request "http://example.com/?q=test", fn ->
        assert {:ok, (target = %Document{})} =
-          ExHal.follow_link(doc, "tmpl", tmpl_vars: %{q: "test"})
+          ExHal.follow_link(doc, "tmpl", tmpl_vars: [q: "test"])
 
         assert {:ok, "http://example.com/?q=test"} = ExHal.url(target)
       end
@@ -198,7 +198,7 @@ defmodule ExHalFacts do
     test ".follow_links w/ templated link" do
       stub_request "http://example.com/?q=test", fn ->
        assert [{:ok, (target = %Document{})}] =
-          ExHal.follow_links(doc, "tmpl", tmpl_vars: %{q: "test"})
+          ExHal.follow_links(doc, "tmpl", tmpl_vars: [q: "test"])
 
         assert {:ok, "http://example.com/?q=test"} = ExHal.url(target)
       end
@@ -263,7 +263,8 @@ defmodule ExHalFacts do
 
 
     def stub_post_request(url, opts \\ %{}, block) do
-      resp = Dict.get opts, :resp, fn (_) -> hal_str(url) end
+      opts = Map.new(opts)
+      resp = Map.get opts, :resp, fn (_) -> hal_str(url) end
 
       use_cassette :stub, [url: url, method: "post", request_body: resp, body: resp, status_code: 201]  do
         block.()


### PR DESCRIPTION
## CHANGES

  * Updated the `ExHal.Document` struct to support a new key,
    `headers`.  This gets set when you parse a response from following
    a link or making a post.  By default, this value is just an empty
    map.  In the case you are manually parsing hal documents from
    strings, the default value will be set in `headers`.  Old APIs
    still work.

  * Removed the `ExHal.Document.listify` function in favor of using
    `List.wrap`

  * Added excoveralls as a test dependency to figure out the test
    coverage percentages.

## EXTRA NOTES

  * As part of this addition, I removed all instances of `Dict` in
    favor of using `Map` and, in one case, Keyword (for HTTPoision's
    API). The reason for this is because `Dict` is currently
    soft-deprecated and will be removed in future releases of Elixir.

  * I also wasn't able to verify that the headers are being sent
    through VCR, but I did test the whole path manually and it does work.