### PR TITLE
Adding Hal Document serialization into a json-like shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ExHal
 =====
 
-[![Build Status](https://travis-ci.org/pezra/exhal.svg?branch=master)](https://travis-ci.org/pezra/exhal) 
+[![Build Status](https://travis-ci.org/pezra/exhal.svg?branch=master)](https://travis-ci.org/pezra/exhal)
 [![Hex.pm](https://img.shields.io/hexpm/v/exhal.svg)](https://hex.pm/packages/exhal)
 
 An easy to use [HAL](http://stateless.co/hal_specification.html) API client for elixir.
@@ -109,6 +109,17 @@ iex> Stream.map(collection, fn follow_results ->
 ["http://example.com/beginning", "http://example.com/middle", "http://example.com/end"]
 ```
 
+### Serialization
+
+Collections and Document can render themselves to a json-like
+structure that can then be serialized using your favorite json encoder
+(e.g. Poison):
+
+    ExHal.Collection.to_json_hash([ex_hal_doc]) |> Poison.encode!
+
+or
+
+    ExHal.Document.to_json_hash(ex_hal_doc) |> Poison.encode!
 
 
 Installation

--- a/lib/exhal/collection.ex
+++ b/lib/exhal/collection.ex
@@ -3,6 +3,8 @@ defmodule ExHal.Collection do
     Utility functions for dealing with RFC 6473 collections
     """
 
+  alias ExHal.Document
+
   @doc """
     Returns a stream that iterate over the collection represented by `a_doc`.
     """
@@ -18,5 +20,11 @@ defmodule ExHal.Collection do
       end,
       fn _ -> nil end
     )
+  end
+
+  @doc """
+  """
+  def to_json_hash(enum) do
+    %{ "_embedded" => %{"item" => Enum.map(enum, &(Document.to_json_hash(&1)))} }
   end
 end

--- a/lib/exhal/link.ex
+++ b/lib/exhal/link.ex
@@ -91,6 +91,21 @@ defmodule ExHal.Link do
     |> Enum.map(fn rel -> %{link | rel: rel} end)
   end
 
+  def embedded?(link) do
+    !!link.target
+  end
+
+  def to_json_hash(link) do
+    if embedded?(link) do
+      Document.to_json_hash(link.target)
+    else
+      hash = %{"href" => link.href}
+      if !!link.templated, do: hash = Map.merge(hash, %{"templated" => true})
+      if !!link.name, do: hash = Map.merge(hash, %{"name" => link.name})
+      hash
+    end
+  end
+
   defp with_url(link, tmpl_vars, fun) do
     case target_url(link, tmpl_vars) do
       {:ok, url} -> fun.(url)

--- a/test/exhal/collection_test.exs
+++ b/test/exhal/collection_test.exs
@@ -6,6 +6,16 @@ defmodule ExHal.CollectionTest do
   alias ExHal.Collection
   alias ExHal.Client
 
+  test ".to_json_hash", context do
+    parsed_hal = %{
+      "name" => "My Name",
+      "_embedded" => %{ "test" => %{"_embedded" => %{}, "_links" => %{}, "name" => "Is Test"}},
+      "_links" => %{ "self" => %{"href" => "http://example.com/my-name"}}}
+
+    doc = Document.from_parsed_hal(context[:client], parsed_hal)
+    assert %{"_embedded" => %{"item" => [^parsed_hal]}} = Collection.to_json_hash([doc])
+  end
+
   test ".to_stream(non_collection_doc) succeeds", ctx do
     assert Collection.to_stream(ctx[:non_collection_doc]) |> is_a_stream
   end

--- a/test/exhal/document_test.exs
+++ b/test/exhal/document_test.exs
@@ -17,6 +17,19 @@ defmodule ExHal.DocumentTest do
     assert Document.parse(context[:client], "{}") |> is_hal_doc?
   end
 
+  test ".to_json_hash", context do
+    parsed_hal = %{
+      "name" => "My Name",
+      "_embedded" => %{ "test" => %{"_embedded" => %{}, "_links" => %{}, "name" => "Is Test"}},
+      "_links" => %{ "self" => %{"href" => "http://example.com/my-name"},
+                     "foo" => [
+                       %{"href" => "http://example.com/my-name"},
+                       %{"href" => "http://example.com/my-foo"},
+                     ]}}
+
+    doc = Document.from_parsed_hal(context[:client], parsed_hal)
+    assert ^parsed_hal = Document.to_json_hash(doc)
+  end
 
   # Background
 

--- a/test/exhal/link_test.exs
+++ b/test/exhal/link_test.exs
@@ -68,6 +68,11 @@ defmodule ExHal.LinkTest do
                                                                   %{q: "hello"})
   end
 
+  test ".embedded?" do
+    assert true == Link.embedded?(%Link{target: %Document{}})
+    assert false == Link.embedded?(%Link{href: "https://aa/resource"})
+  end
+
   defmodule HttpRequesting do
     use ExUnit.Case, async: false
     use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney


### PR DESCRIPTION
  NOTE: Actual encoding is left up to the user. For example,
  you will want to do something like this to make real JSON:

     ExHal.Collection.to_json_hash([ex_hal_doc]) |> Poison.encode!

  or

     ExHal.Document.to_json_hash(ex_hal_doc) |> Poison.encode!

  or

     ExHal.Link.to_json_hash(ex_hal_link) |> Poison.encode!