### PR TITLE
Link target

### DIFF
--- a/lib/exhal.ex
+++ b/lib/exhal.ex
@@ -115,13 +115,19 @@ defmodule ExHal do
     %Client{}
   end
 
-  defdelegate [follow_link(a_doc, name),
-               follow_link(a_doc, name, opts),
-               follow_links(a_doc, name),
-               follow_links(a_doc, name, opts),
-               post(a_doc, name, body),
-               post(a_doc, name, body, opts)],
-               to: Navigation
+  defdelegate [
+    follow_link(a_doc, name),
+    follow_link(a_doc, name, opts),
+
+    follow_links(a_doc, name),
+    follow_links(a_doc, name, opts),
+
+    post(a_doc, name, body),
+    post(a_doc, name, body, opts),
+
+    link_target(a_doc, name),
+    link_target(a_doc, name, opts)
+  ], to: Navigation
 
   @doc """
   Fetches value of specified property or links whose `rel` matches

--- a/lib/exhal.ex
+++ b/lib/exhal.ex
@@ -103,10 +103,7 @@ defmodule ExHal do
     """
 
 
-  alias ExHal.Link
-  alias ExHal.Error
-  alias ExHal.Client
-  alias ExHal.Navigation
+  alias ExHal.{Client,Navigation}
 
   @doc """
     Returns a default client

--- a/lib/exhal/link.ex
+++ b/lib/exhal/link.ex
@@ -4,10 +4,7 @@ defmodule ExHal.Link do
     are found in the `_links` and `_embedded` sections of a HAL document
   """
 
-  alias ExHal.Error
-  alias ExHal.Document
-  alias ExHal.NsReg
-  alias ExHal.Client
+  alias ExHal.{Document,NsReg}
 
   defstruct [:rel, :href, :templated, :name, :target]
 
@@ -85,12 +82,4 @@ defmodule ExHal.Link do
       hash
     end
   end
-
-  defp with_url(link, tmpl_vars, fun) do
-    case target_url(link, tmpl_vars) do
-      {:ok, url} -> fun.(url)
-      :error -> {:error, %Error{reason: "Unable to determine target url"} }
-    end
-  end
-
 end

--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -70,6 +70,29 @@ defmodule ExHal.Navigation do
     end
   end
 
+  @doc """
+    Returns `{:ok, url}` if a matching link is found or `{:error, %ExHal.Error{...}}` if not.
+
+    * a_doc - `ExHal.Document` in which to search for links
+    * name - the rel of the link of interest
+    * opts
+      * `:tmpl_vars` - `Map` of variables with which to expand any templates found. Default: `%{}`
+      * `:strict` - true if the existance of multiple matching links should cause a failure. Default: `false`
+    """
+  def link_target(a_doc, name, opts \\ %{}) do
+    opts = Map.new(opts)
+    tmpl_vars = Map.get(opts, :tmpl_vars, %{})
+    strict?   = Map.get(opts, :strict, false)
+
+    case figure_link(a_doc, name, !strict?) do
+      {:ok, link} -> case Link.target_url(link, tmpl_vars) do
+                       {:ok, url} -> {:ok, url}
+                       :error -> {:error, %Error{reason: "link has no href member"}}
+                     end
+      (r = _) -> r
+    end
+  end
+
   # privates
 
   defp figure_link(a_doc, name, pick_volunteer?) do

--- a/lib/exhal/non_hal_response.ex
+++ b/lib/exhal/non_hal_response.ex
@@ -9,12 +9,10 @@ defmodule ExHal.NonHalResponse do
 end
 
 defimpl ExHal.Locatable, for: ExHal.NonHalResponse do
-  alias ExHal.Link
-
   def url(a_resp) do
     a_resp.headers
     |> Enum.find({nil, :error},
-      fn {field_name, value} -> Regex.match?(~r/(content-)?location/i, field_name) end)
+      fn {field_name, _} -> Regex.match?(~r/(content-)?location/i, field_name) end)
     |> (fn {_,url} -> url end).()
   end
 end

--- a/test/exhal/navigation_test.exs
+++ b/test/exhal/navigation_test.exs
@@ -4,8 +4,7 @@ defmodule ExHal.NavigationTest do
   use ExUnit.Case, async: false
   use RequestStubbing
 
-  alias ExHal.Navigation
-  alias ExHal.Document
+  alias ExHal.{Navigation,Document,Error}
 
   test ".follow_link", %{doc: doc} do
     thing_hal = hal_str("http://example.com/thing")
@@ -44,6 +43,18 @@ defmodule ExHal.NavigationTest do
     end
   end
 
+  test ".link_target", %{doc: doc} do
+    assert {:ok, "http://example.com/"} = Navigation.link_target(doc, "single")
+
+    assert {:ok, "http://example.com/?q=hello"} = Navigation.link_target(doc, "tmpl", tmpl_vars: %{q: "hello"})
+
+    assert {:ok, l} = Navigation.link_target(doc, "multiple")
+    assert "http://example.com/1" == l or "http://example.com/2" == l
+
+    assert {:error, %Error{}} = Navigation.link_target(doc, "multiple", strict: true)
+
+    assert {:error, %Error{}} = Navigation.link_target(doc, "nonexistent")
+  end
 
   # Background
 

--- a/test/exhal_test.exs
+++ b/test/exhal_test.exs
@@ -48,6 +48,11 @@ defmodule ExHalTest do
         ExHal.fetch(doc, "profile")
     end
 
+    test "urls can be extracted from links" do
+      assert {:ok, "http://example.com"} =
+        ExHal.link_target(doc, "profile")
+    end
+
     test "missing links cannot be fetched" do
       assert :error = ExHal.fetch(doc, "author")
     end


### PR DESCRIPTION
Provides an easy way to retrieve the target of a link in a document.

Also removes some compiler warnings.