### PR TITLE
Adding ExHal.Interpreter module to define mappers in applications

### DIFF
--- a/lib/exhal.ex
+++ b/lib/exhal.ex
@@ -124,7 +124,10 @@ defmodule ExHal do
     post(a_doc, name, body, opts),
 
     link_target(a_doc, name),
-    link_target(a_doc, name, opts)
+    link_target(a_doc, name, opts),
+
+    link_target_lazy(a_doc, name, fun),
+    link_target_lazy(a_doc, name, opts, fun)
   ], to: Navigation
 
   @doc """

--- a/lib/exhal/interpreter.ex
+++ b/lib/exhal/interpreter.ex
@@ -1,0 +1,30 @@
+defmodule ExHal.Interpreter do
+  defmacro __using__(_opts) do
+    quote do
+      import unquote(__MODULE__)
+      Module.register_attribute __MODULE__, :extractors, accumulate: true, persist: false
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      def to_params(doc) do
+        Enum.reduce(@extractors, %{}, &(apply(__MODULE__, &1, [doc, &2])))
+      end
+    end
+  end
+
+  defmacro defextract(name) do
+    extractor_name = :"extract_#{name}"
+
+    quote do
+      def unquote(extractor_name)(doc, params) do
+        value = ExHal.get_lazy(doc, unquote(to_string(name)), fn -> nil end)
+        Map.put(params, unquote(name), value)
+      end
+
+      @extractors unquote(extractor_name)
+    end
+  end
+end

--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -100,6 +100,13 @@ defmodule ExHal.Navigation do
     end
   end
 
+  def link_target_lazy(a_doc, name, opts \\ %{}, fun) do
+    case link_target(a_doc, name, opts) do
+      {:ok, target} -> target
+      {:error, _} -> fun.()
+    end
+  end
+
   # privates
 
   defp figure_link(a_doc, name, pick_volunteer?) do

--- a/test/exhal/interpreter_test.exs
+++ b/test/exhal/interpreter_test.exs
@@ -1,0 +1,38 @@
+defmodule ExHal.InterpreterTest do
+  use ExUnit.Case
+
+  setup do
+    {:ok, doc: %ExHal.Document{properties: %{"thing" => 1, "thing2" => 2}}}
+  end
+
+  test "can we make the most simple interpreter", %{doc: doc} do
+    defmodule MyInterpreter do
+      use ExHal.Interpreter
+    end
+
+    assert MyInterpreter.to_params(doc) == %{}
+  end
+
+  test "trying to extract a property", %{doc: doc} do
+    defmodule MyBetterInterpreter do
+      use ExHal.Interpreter
+
+      defextract :thing
+      defextract :thing2
+    end
+
+    assert MyBetterInterpreter.to_params(doc) == %{thing: 1, thing2: 2}
+  end
+
+  test "trying to extract a property", %{doc: doc} do
+    defmodule MyOverreachingInterpreter do
+      use ExHal.Interpreter
+
+      defextract :thing
+      defextract :thing2
+      defextract :thing3
+    end
+
+    assert MyOverreachingInterpreter.to_params(doc) == %{thing: 1, thing2: 2, thing3: nil}
+  end
+end

--- a/test/exhal/interpreter_test.exs
+++ b/test/exhal/interpreter_test.exs
@@ -2,7 +2,17 @@ defmodule ExHal.InterpreterTest do
   use ExUnit.Case
 
   setup do
-    {:ok, doc: %ExHal.Document{properties: %{"thing" => 1, "thing2" => 2}}}
+    hal = """
+    {
+      "thing" : 1,
+      "TheOtherThing": 2,
+      "_links": {
+        "up": { "href": "http://example.com" }
+      }
+    }
+    """
+
+    {:ok, doc: ExHal.Document.parse!(ExHal.client, hal)}
   end
 
   test "can we make the most simple interpreter", %{doc: doc} do
@@ -13,26 +23,25 @@ defmodule ExHal.InterpreterTest do
     assert MyInterpreter.to_params(doc) == %{}
   end
 
-  test "trying to extract a property", %{doc: doc} do
-    defmodule MyBetterInterpreter do
-      use ExHal.Interpreter
-
-      defextract :thing
-      defextract :thing2
-    end
-
-    assert MyBetterInterpreter.to_params(doc) == %{thing: 1, thing2: 2}
-  end
-
-  test "trying to extract a property", %{doc: doc} do
+  test "trying to extract properties", %{doc: doc} do
     defmodule MyOverreachingInterpreter do
       use ExHal.Interpreter
 
       defextract :thing
-      defextract :thing2
+      defextract :thing2, from: "TheOtherThing"
       defextract :thing3
     end
 
-    assert MyOverreachingInterpreter.to_params(doc) == %{thing: 1, thing2: 2, thing3: nil}
+    assert MyOverreachingInterpreter.to_params(doc) == %{thing: 1, thing2: 2}
+  end
+
+  test "trying to extract links", %{doc: doc} do
+    defmodule MyLinkInterpreter do
+      use ExHal.Interpreter
+
+      defextractlink :mylink, rel: "up"
+    end
+
+    assert MyLinkInterpreter.to_params(doc) == %{mylink: "http://example.com"}
   end
 end


### PR DESCRIPTION
```elixir
defmodule MyInterpreter do
  use ExHal.Intepreter

  defextract :first_name
  defextract :last_name
end
```

This would create a `to_params/1` function on `MyInterpreter` that
would be called with an ExHal.Document:

```elixir
  iex(1)> MyInterpreter.to_params(doc)
  => %{first_name: ..., last_name: ...}
```

If the ExHal.Document does not have a property , it will default that
particular parameter to `nil`