### PR TITLE
make transcoders chainable

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,12 @@ iex> PersonTranscoder.encode!(%{name: "Jane Doe",
 } )
 ```
 
+
 This can be used to, for example, build Ecto changesets via a `changeset/2` functions and to render HAL responses to HTTP requests.
+
+#### Composing
+
+Transcoders are also chainable. For example, given a `ManagerTranscoder` the following would produce a Map that includes all person params and all the manager params: `PersonTranscoder.decode!(doc) |> ManagerTranscoder.decode!(doc)`. Similarly ``PersonTranscoder.encode!(model) |> ManagerTranscoder.encode!(module)` would produce an `ExHal.Document` that has all the properties and links defined in those transcoders.
 
 
 ### Assertions about HAL documents

--- a/lib/exhal/transcoder.ex
+++ b/lib/exhal/transcoder.ex
@@ -84,14 +84,16 @@ defmodule ExHal.Transcoder do
 
   defmacro __before_compile__(_env) do
     quote do
-      def decode!(doc) do
+      def decode!(doc), do: decode!(%{}, doc)
+      def decode!(initial_params, doc) do
         @extractors
-        |> Enum.reduce(%{}, &(apply(__MODULE__, &1, [doc, &2])))
+        |> Enum.reduce(initial_params, &(apply(__MODULE__, &1, [doc, &2])))
       end
 
-      def encode!(params) do
+      def encode!(params), do: encode!(%ExHal.Document{}, params)
+      def encode!(initial_doc, params) do
         @injectors
-        |> Enum.reduce(%ExHal.Document{}, &(apply(__MODULE__, &1, [&2, params])))
+        |> Enum.reduce(initial_doc, &(apply(__MODULE__, &1, [&2, params])))
       end
     end
   end
@@ -225,4 +227,5 @@ defmodule ExHal.Transcoder do
   def put_property(value, doc, prop_name) do
     ExHal.Document.put_property(doc, prop_name, value)
   end
+
 end


### PR DESCRIPTION
from readme
>Transcoders are also chainable. For example, given a `ManagerTranscoder` the following would produce a Map that includes all person params and all the manager params: `PersonTranscoder.decode!(doc) |> ManagerTranscoder.decode!(doc)`. Similarly ``PersonTranscoder.encode!(model) |> ManagerTranscoder.encode!(module)` would produce an `ExHal.Document` that has all the properties and links defined in those transcoders.