### PR TITLE
find and supply embedded target links to value decoders when transcoding

### DIFF
--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -132,6 +132,10 @@ defmodule ExHal.Navigation do
 
   # privates
 
+  defp find_link_target(%ExHal.Link{target: %ExHal.Document{}} = link, tmpl_vars) do
+    {:ok, link.target}
+  end
+
   defp find_link_target(link, tmpl_vars) do
     case Link.target_url(link, tmpl_vars) do
       :error -> {:error, %Error{reason: "link has no href member"}}

--- a/test/exhal/navigation_test.exs
+++ b/test/exhal/navigation_test.exs
@@ -50,7 +50,9 @@ defmodule ExHal.NavigationTest do
 
   test ".link_target", %{doc: doc} do
     assert {:ok, "http://example.com/"} = Navigation.link_target(doc, "single")
-    assert {:ok, "http://example.com/e"} = Navigation.link_target(doc, "embedded")
+
+    embedded_linked_doc = doc.links["embedded"] |> List.first |> Map.get(:target)
+    assert {:ok, embedded_linked_doc} = Navigation.link_target(doc, "embedded")
 
     assert {:ok, "http://example.com/?q=hello"} = Navigation.link_target(doc, "tmpl", tmpl_vars: %{q: "hello"})
 


### PR DESCRIPTION
It's my understanding that with HAL it should be possible to provide embedded documents as links. We do this over at @compose in our internal services all the time. In that case, I believe the client should refer to the target document directly rather than use the href to make a request. It seems as though this was the intention in the Exhal code, as it mentions the target, but it did not do so. With this PR it supplies the embedded document if one is provided. I have also updated the tests accordingly.