### PR TITLE
Adds templated link support when transcoding HAL documents and Maps

### DIFF
--- a/lib/exhal/document.ex
+++ b/lib/exhal/document.ex
@@ -174,9 +174,9 @@ defmodule ExHal.Document do
 
     Returns new ExHal.Document with the specified link.
   """
-  def put_link(doc, rel, target) do
+  def put_link(doc, rel, target, templated \\ false) do
     new_rel_links = Map.get(doc.links, rel, []) ++
-      [%ExHal.Link{rel: rel, href: target, templated: false, name: nil}]
+      [%ExHal.Link{rel: rel, href: target, templated: templated, name: nil}]
 
     %{doc | links: Map.put(doc.links, rel, new_rel_links)}
   end


### PR DESCRIPTION
  Given the following:

```elixir
  defmodule MyTranscoder do
    use ExHal.Transcoder

    deflink "fillmein", param: :fillmein, templated: true
  end
```

  When you call `MyTranscoder.decode!(doc)` on a HAL document that looks like
  this:

```json
  {
    "_links": {
       "fillmein": { "href": "http://example.com/resource{?data}", "templated": true}
    }
  }
```

  Then you will still have the templated link in it's original form in
  the decoded struct like so:

```elixir
  %{fillmein: "http://example.com/resource{?data}"}
```
  =============================================================================

  NOTE: This provides a clear distinction of making links templated or
  not whereas before `templated` was always set to `false` by the
  encoder/decoder.