### PR TITLE
Allow re-use of param in `ExHal.Transcoder`

### DIFF
--- a/lib/exhal/transcoder.ex
+++ b/lib/exhal/transcoder.ex
@@ -179,11 +179,13 @@ defmodule ExHal.Transcoder do
   end
 
   defp interpret_opts(options, name) do
+    unique_string = (:rand.uniform * 100_000_000) |> trunc |> Integer.to_string
+
     param_names = options |> Keyword.get(:param, String.to_atom(name)) |> List.wrap
     templated = options |> Keyword.get(:templated, false)
     value_converter = Keyword.get(options, :value_converter, IdentityConverter)
-    extractor_name = :"extract_#{Enum.join(param_names,".")}"
-    injector_name = :"inject_#{Enum.join(param_names,".")}"
+    extractor_name = :"extract_#{unique_string}_#{Enum.join(param_names,".")}"
+    injector_name = :"inject_#{unique_string}_#{Enum.join(param_names,".")}"
 
     {param_names, value_converter, extractor_name, injector_name, templated}
   end

--- a/test/exhal/transcoder_test.exs
+++ b/test/exhal/transcoder_test.exs
@@ -58,6 +58,20 @@ defmodule ExHal.TranscoderTest do
     assert :missing == ExHal.get_lazy(encoded, "missingThing", fn -> :missing end)
   end
 
+  test "re-using transcode params" do
+    defmodule MySimpleTranscoder do
+      use ExHal.Transcoder
+
+      defproperty "firstUse",  param: :thing
+      defproperty "secondUse", param: :thing
+    end
+
+    encoded = MySimpleTranscoder.encode!(%{thing: "thing_value"})
+
+    assert "thing_value" == ExHal.get_lazy(encoded, "firstUse",  fn -> :missing end)
+    assert "thing_value" == ExHal.get_lazy(encoded, "secondUse", fn -> :missing end)
+  end
+
   test "transcoding with dynamic value converters" do
     defmodule DynamicConverter do
       @behaviour ExHal.Transcoder.ValueConverterWithOptions


### PR DESCRIPTION
When using a param name twice in a transcoder, like so:

```elixir
defmodule HawaiiTranscoder do
  use ExHal.Transcoder

  defproperty "hello", param: :aloha
  defproperty "goodbye", param: :aloha
end
```

And then trying to encode a document:
```elixir
HawaiiTranscoder.encode!(%{aloha: "aloha"})`
```

The resulting document lacks properties based off the same parameter after the first one:
```elixir
%ExHal.Document{client: true, links: %{}, properties: %{"hello" => "aloha"}}
```

This comes from the `@injectors` and `@extractors` being built programmatically from the `param` name, then accumulated into the respective module variable.  When looking through the `@injectors` or `@extractors` at run-time, the same (identical) one is found each time.  This leads, in this case, to `"hello"` being added to the document once, then overwritten the second time.  And the second property is not generated.  _Or something like that_

The change herein adds some uniqueness to the `injector_name` and `extractor_name`.  There are undoubtedly better ways to do this, but in general this approach works.  

Alternatively, it might work to pass the property `name` into `ExHal.Transcoder.interpret_opts` and generate the injector names that way.  Those should be unique as well.