### PR TITLE
Add elixir 1.4; drop OTP 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: elixir
 
 elixir:
   - 1.3
+  - 1.4
 
 otp_release:
-  - 17.4
-  - 18.2
-  - 19.0
+  - 18.3
+  - 19.3


### PR DESCRIPTION
* Elixir 1.3 doesn't work with OTP < 18, builds were being forced up to 18 anyway 