### PR TITLE
Request logs reflect the actual time spent

### DIFF
--- a/lib/exhal.ex
+++ b/lib/exhal.ex
@@ -109,7 +109,7 @@ defmodule ExHal do
     Returns a default client
     """
   def client do
-    %Client{}
+    Client.new()
   end
 
   defdelegate follow_link(a_doc, name), to: Navigation

--- a/test/exhal/client_test.exs
+++ b/test/exhal/client_test.exs
@@ -2,6 +2,7 @@ Code.require_file "../support/request_stubbing.exs", __DIR__
 
 defmodule ExHal.ClientTest do
   use ExUnit.Case, async: true
+  doctest ExHal.Client
 
   alias ExHal.Client
 


### PR DESCRIPTION
Previously times were in microseconds but labeled as milliseconds. Confusing!