### PR TITLE
Merge links in `_links` and `_embedded` sections

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,12 +24,14 @@ defmodule ExHal.Mixfile do
       {:uri_template, "~> 1.0"},
       {:httpoison, "~> 0.11 or ~> 1.0"},
       {:odgn_json_pointer, "~> 1.0.0", app: false},
+      {:expat, "~> 1.0"},
       {:earmark, ">= 0.0.0", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
       {:dialyxir, "~> 0.3", only: :dev, runtime: false},
       {:exvcr, "~> 0.7", only: :test},
       {:excoveralls, "~> 0.4", only: :test},
-      {:mox, "~> 0.3", only: :test}
+      {:mox, "~> 0.3", only: :test},
+      {:stream_data, "~> 0.1", only: :test}
     ]
     |> dep_version_overrides
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExHal.Mixfile do
     [
       app: :exhal,
       description: "Use HAL APIs with ease",
-      version: "7.1.0",
+      version: "7.1.1",
       elixir: "~> 1.5",
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test],

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,4 @@
-%{
-  "amrita": {:git, "git://github.com/josephwilk/amrita.git", "f51ae5225fb77ed0238e29fc80dbfa95e77c3ceb", []},
+%{"amrita": {:git, "git://github.com/josephwilk/amrita.git", "f51ae5225fb77ed0238e29fc80dbfa95e77c3ceb", []},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
@@ -7,6 +6,7 @@
   "exactor": {:hex, :exactor, "2.2.3", "a6972f43bb6160afeb73e1d8ab45ba604cd0ac8b5244c557093f6e92ce582786", [:mix], []},
   "excoveralls": {:hex, :excoveralls, "0.7.0", "05cb3332c2b0f799df3ab90eb7df1ae5a147c86776e91792848a12b7ed87242f", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
+  "expat": {:hex, :expat, "1.0.5", "994ff9872139038432241bc05957dc7ba114f87fa7ed362c6fea32cd98d7fb19", [], [], "hexpm"},
   "exvcr": {:hex, :exvcr, "0.10.2", "a66a0fa86d03153e5c21e38b1320d10b537038d7bc7b10dcc1ab7f0343569822", [:mix], [{:exactor, "~> 2.2", [hex: :exactor, repo: "hexpm", optional: false]}, {:exjsx, "~> 4.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:httpoison, "~> 1.0", [hex: :httpoison, repo: "hexpm", optional: true]}, {:httpotion, "~> 3.1", [hex: :httpotion, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:meck, "~> 0.8", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.12.1", "8bf2d0e11e722e533903fe126e14d6e7e94d9b7983ced595b75f532e04b7fdc7", [:rebar3], [{:certifi, "2.3.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.1", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.1.1", "96ed7ab79f78a31081bb523eefec205fd2900a02cda6dbc2300e7a1226219566", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
@@ -21,6 +21,6 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []},
+  "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
-  "uri_template": {:hex, :uri_template, "1.2.0", "8ad4d58c1bf9304c50e0d126cb42d699988972177851e0563ba4c9efe1c1d8b0", [:mix], []},
-}
+  "uri_template": {:hex, :uri_template, "1.2.0", "8ad4d58c1bf9304c50e0d126cb42d699988972177851e0563ba4c9efe1c1d8b0", [:mix], []}}

--- a/test/exhal/document_test.exs
+++ b/test/exhal/document_test.exs
@@ -176,7 +176,7 @@ defmodule ExHal.DocumentTest do
     end
   end
 
-  defmodule DocWithWithDuplicateLinks do
+  defmodule DocWithWithRepeatedLinks do
     use ExUnit.Case, async: true
     defp doc, do: Document.parse! ExHal.client, ~s({"_links": {
                                      "item": [
@@ -187,6 +187,30 @@ defmodule ExHal.DocumentTest do
 
     test "links can be fetched" do
       assert {:ok, [_, _] } = Document.fetch(doc(), "item")
+    end
+  end
+
+  defmodule DocWithWithDuplicateLinksAndEmbedded do
+    use ExUnit.Case, async: true
+    defp doc, do: Document.parse! ExHal.client, ~s(
+          { "_links": {
+              "item": [
+                {"href": "http://example.com/1"}
+              ]
+            },
+            "_embedded": {
+              "item": {
+                "name": "Peter",
+                "_links": {
+                  "self": { "href": "http://example.com/1"}
+                }
+              }
+            }
+          }
+        )
+
+    test "links can be fetched" do
+      assert 1 == Document.fetch(doc(), "item") |> elem(1) |>  Enum.count()
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,6 @@
 ExUnit.start
 Application.ensure_all_started(:mox)
+Application.ensure_all_started(:stream_data)
 
 Mox.defmock(ExHal.ClientMock, for: ExHal.Client)
 


### PR DESCRIPTION
Allows CGJ producer to follow the best practice of putting links in *both* the `_links` section and the `_embedded` section.