### PR TITLE
non-HAL responses correctly implement Locatable protocol

### DIFF
--- a/lib/exhal/non_hal_response.ex
+++ b/lib/exhal/non_hal_response.ex
@@ -9,9 +9,10 @@ end
 defimpl ExHal.Locatable, for: ExHal.NonHalResponse do
   def url(a_resp) do
     a_resp.headers
-    |> Enum.find({nil, :error}, fn {field_name, _} ->
-      Regex.match?(~r/(content-)?location/i, field_name)
-    end)
-    |> (fn {_, url} -> url end).()
+    |> Enum.find(fn {field_name, _} -> Regex.match?(~r/(content-)?location/i, field_name) end)
+    |> case do
+         nil -> :error
+         {_, url} -> {:ok, url}
+       end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExHal.Mixfile do
     [
       app: :exhal,
       description: "Use HAL APIs with ease",
-      version: "7.1.1",
+      version: "7.1.2",
       elixir: "~> 1.5",
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test],

--- a/test/exhal/non_hal_response_test.exs
+++ b/test/exhal/non_hal_response_test.exs
@@ -2,22 +2,23 @@ defmodule ExHal.NonHalResponseTest do
   use ExUnit.Case, async: true
   alias ExHal.NonHalResponse
 
-  test "Locatable with Location header" do
-    r = %NonHalResponse{status_code: 200, headers: [{"Location", "http://example.com"}], body: ""}
+  describe ".url/1" do
+    test "with Location header" do
+      r = %NonHalResponse{status_code: 200, headers: [{"Location", "http://example.com"}], body: ""}
 
-    assert "http://example.com" == ExHal.Locatable.url(r)
+      assert {:ok, "http://example.com"} == ExHal.Locatable.url(r)
+    end
+
+    test "with Content-Location header" do
+      r = %NonHalResponse{status_code: 200, headers: [{"Content-Location", "http://example.com"}], body: ""}
+
+      assert {:ok, "http://example.com"} == ExHal.Locatable.url(r)
+    end
+
+    test "with non-locatable response" do
+      r = %NonHalResponse{status_code: 200, headers: [], body: ""}
+
+      assert :error == ExHal.Locatable.url(r)
+    end
   end
-
-  test "Locatable with Content-Location header" do
-    r = %NonHalResponse{status_code: 200, headers: [{"Content-Location", "http://example.com"}], body: ""}
-
-    assert "http://example.com" == ExHal.Locatable.url(r)
-  end
-
-  test "Locatable with non-locatable response" do
-    r = %NonHalResponse{status_code: 200, headers: [], body: ""}
-
-    assert :error == ExHal.Locatable.url(r)
-  end
-
 end


### PR DESCRIPTION
Previously there was a bug which caused non-HAL response to return a bare URL rather than an `{:ok, url` tuple as specified by the `Locatable.url/1` typespec.