### PR TITLE
Make `ExHal.Navigation.follow_links/4` concurrent.

### DIFF
--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -12,9 +12,8 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if not
   """
   def follow_link(a_doc, name, opts \\ %{tmpl_vars: %{}, strict: false, headers: []}) do
-    opts = Map.new(opts)
+    {tmpl_vars, opts} = tmpl_vars_and_opts_map(opts)
     pick_volunteer? = !Map.get(opts, :strict, false)
-    tmpl_vars = Map.get(opts, :tmpl_vars, %{})
 
     case figure_link(a_doc, name, pick_volunteer?) do
       {:error, e} -> {:error, e}
@@ -54,8 +53,8 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if response is an error if not
   """
   def post(a_doc, name, body, opts \\ %{tmpl_vars: %{}, strict: true}) do
+    {tmpl_vars, opts} = tmpl_vars_and_opts_map(opts)
     pick_volunteer? = !Map.get(opts, :strict, true)
-    tmpl_vars = Map.get(opts, :tmpl_vars, %{})
 
     case figure_link(a_doc, name, pick_volunteer?) do
       {:error, e} -> {:error, e}
@@ -70,8 +69,8 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if response is an error if not
   """
   def put(a_doc, name, body, opts \\ %{tmpl_vars: %{}, strict: true}) do
+    {tmpl_vars, opts} = tmpl_vars_and_opts_map(opts)
     pick_volunteer? = !Map.get(opts, :strict, true)
-    tmpl_vars = Map.get(opts, :tmpl_vars, %{})
 
     case figure_link(a_doc, name, pick_volunteer?) do
       {:error, e} -> {:error, e}
@@ -86,8 +85,8 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if response is an error if not
   """
   def patch(a_doc, name, body, opts \\ %{tmpl_vars: %{}, strict: true}) do
+    {tmpl_vars, opts} = tmpl_vars_and_opts_map(opts)
     pick_volunteer? = !Map.get(opts, :strict, true)
-    tmpl_vars = Map.get(opts, :tmpl_vars, %{})
 
     case figure_link(a_doc, name, pick_volunteer?) do
       {:error, e} -> {:error, e}
@@ -105,8 +104,7 @@ defmodule ExHal.Navigation do
     * `:strict` - true if the existence of multiple matching links should cause a failure. Default: `false`
   """
   def link_target(a_doc, name, opts \\ %{}) do
-    opts = Map.new(opts)
-    tmpl_vars = Map.get(opts, :tmpl_vars, %{})
+    {tmpl_vars, opts} = tmpl_vars_and_opts_map(opts)
     strict? = Map.get(opts, :strict, false)
 
     case figure_link(a_doc, name, !strict?) do
@@ -124,8 +122,7 @@ defmodule ExHal.Navigation do
     * `:tmpl_vars` - `Map` of variables with which to expand any templates found. Default: `%{}`
   """
   def link_targets(a_doc, name, opts \\ %{}) do
-    opts = Map.new(opts)
-    tmpl_vars = Map.get(opts, :tmpl_vars, %{})
+    {tmpl_vars, opts} = tmpl_vars_and_opts_map(opts)
 
     case ExHal.get_links_lazy(a_doc, name, fn -> :missing end) do
       :missing ->
@@ -182,7 +179,7 @@ defmodule ExHal.Navigation do
   end
 
   defp _follow_links(client, links, %{} = opts) do
-    tmpl_vars = Map.get(opts, :tmpl_vars, %{})
+    {tmpl_vars, opts} = tmpl_vars_and_opts_map(opts)
 
     links
     |> Task.async_stream(&_follow_link(client, &1, tmpl_vars, opts))
@@ -197,5 +194,15 @@ defmodule ExHal.Navigation do
       true ->
         @client_module.get(client, Link.target_url!(link, tmpl_vars), opts)
     end
+  end
+
+  defp tmpl_vars_and_opts_map(%{} = opts) do
+    Map.pop(opts, :tmpl_vars, %{})
+  end
+
+  defp tmpl_vars_and_opts_map(opts) do
+    opts
+    |> Map.new()
+    |> tmpl_vars_and_opts_map()
   end
 end

--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -42,7 +42,10 @@ defmodule ExHal.Navigation do
 
     case ExHal.get_links_lazy(a_doc, name, fn -> :missing end) do
       :missing -> missing_link_handler.(name)
-      links -> Enum.map(links, &_follow_link(a_doc.client, &1, tmpl_vars, opts))
+      links ->
+        links
+        |> Task.async_stream(&_follow_link(a_doc.client, &1, tmpl_vars, opts))
+        |> Enum.map(fn {:ok, followed_link} -> followed_link end)
     end
   end
 

--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -203,7 +203,7 @@ defmodule ExHal.Navigation do
       Link.embedded?(link) ->
         {:ok, link.target, %ResponseHeader{status_code: 200}}
 
-      true ->
+      :else ->
         @client_module.get(client, Link.target_url!(link, tmpl_vars), opts)
     end
   end

--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -54,12 +54,7 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if response is an error if not
   """
   def post(a_doc, name, body, opts \\ %{tmpl_vars: %{}, strict: true}) do
-    {tmpl_vars, strict?, opts} = interpret_nav_opts(opts)
-
-    case figure_link(a_doc, name, strict?) do
-      {:error, e} -> {:error, e}
-      {:ok, link} -> @client_module.post(a_doc.client, Link.target_url!(link, tmpl_vars), body, opts)
-    end
+    update_document(a_doc, name, body, opts, &@client_module.post/4)
   end
 
   @doc """
@@ -69,12 +64,7 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if response is an error if not
   """
   def put(a_doc, name, body, opts \\ %{tmpl_vars: %{}, strict: true}) do
-    {tmpl_vars, strict?, opts} = interpret_nav_opts(opts)
-
-    case figure_link(a_doc, name, strict?) do
-      {:error, e} -> {:error, e}
-      {:ok, link} -> @client_module.put(a_doc.client, Link.target_url!(link, tmpl_vars), body, opts)
-    end
+    update_document(a_doc, name, body, opts, &@client_module.put/4)
   end
 
   @doc """
@@ -84,11 +74,15 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if response is an error if not
   """
   def patch(a_doc, name, body, opts \\ %{tmpl_vars: %{}, strict: true}) do
+    update_document(a_doc, name, body, opts, &@client_module.patch/4)
+  end
+
+  defp update_document(a_doc, name, body, opts, fun) do
     {tmpl_vars, strict?, opts} = interpret_nav_opts(opts)
 
     case figure_link(a_doc, name, strict?) do
       {:error, e} -> {:error, e}
-      {:ok, link} -> @client_module.patch(a_doc.client, Link.target_url!(link, tmpl_vars), body, opts)
+      {:ok, link} -> fun.(a_doc.client, Link.target_url!(link, tmpl_vars), body, opts)
     end
   end
 

--- a/test/exhal_test.exs
+++ b/test/exhal_test.exs
@@ -170,6 +170,10 @@ defmodule ExHalTest do
       assert {:error, %ExHal.Error{}} = ExHal.follow_link(doc(), "absent")
     end
 
+    test ".follow_link w/ malformed URL" do
+      assert catch_error(ExHal.follow_link(doc("/boom"), "single"))
+    end
+
     test ".follow_link w/ multiple links with strict true fails" do
       assert {:error, %ExHal.Error{}} = ExHal.follow_link(doc(), "multiple", strict: true)
     end
@@ -243,11 +247,8 @@ defmodule ExHalTest do
       end
     end
 
-    test ".follow_links to non-existent URLs" do
-      ExHal.follow_links(doc(0), "multiple")
-      |> Enum.each(fn resp ->
-        assert {:error, %ExHal.Error{}} = resp
-      end)
+    test ".follow_links to malformed URLs" do
+      assert catch_error(ExHal.follow_links(doc("/boom"), "multiple"))
     end
 
     test ".post w/ normal link" do

--- a/test/exhal_test.exs
+++ b/test/exhal_test.exs
@@ -216,7 +216,38 @@ defmodule ExHalTest do
     end
 
     test ".follow_links w/ multiple links" do
-      # exvcr fail
+      stub_request "get", url: "~r/http:\/\/example.com\/[12]/", resp_body: hal_str("") do
+        ExHal.follow_links(doc(), "multiple")
+        |> Enum.each(fn resp ->
+          assert {:ok, target = %Document{}, %ResponseHeader{status_code: 200}} = resp
+          assert {:ok, _} = ExHal.url(target)
+        end)
+      end
+    end
+
+    test ".follow_links w/ non-HAL responses" do
+      stub_request "get", url: "~r/http:\/\/example.com\/[12]/", resp_body: "" do
+        ExHal.follow_links(doc(), "multiple")
+        |> Enum.each(fn resp ->
+          assert {:ok, %ExHal.NonHalResponse{}, _} = resp
+        end)
+      end
+    end
+
+    test ".follow_links w/ non-200 status" do
+      stub_request "get", url: "~r/http:\/\/example.com\/[12]/", resp_body: hal_str(""), resp_status: 500 do
+        ExHal.follow_links(doc(), "multiple")
+        |> Enum.each(fn resp ->
+          assert {:error, %Document{}, %ResponseHeader{status_code: 500}} = resp
+        end)
+      end
+    end
+
+    test ".follow_links to non-existent URLs" do
+      ExHal.follow_links(doc(0), "multiple")
+      |> Enum.each(fn resp ->
+        assert {:error, %ExHal.Error{}} = resp
+      end)
     end
 
     test ".post w/ normal link" do
@@ -239,16 +270,16 @@ defmodule ExHalTest do
       end
     end
 
-    defp doc do
+    defp doc(scheme_and_domain \\ "http://example.com/") do
       ExHal.Document.from_parsed_hal(ExHal.client,
         %{"_links" =>
-           %{"single" => %{ "href" => "http://example.com/" },
-             "tmpl" => %{ "href" => "http://example.com/{?q}", "templated" => true },
-             "multiple" => [%{ "href" => "http://example.com/1" },
-                            %{ "href" => "http://example.com/2" }]
+          %{"single" => %{ "href" => scheme_and_domain },
+            "tmpl" => %{ "href" => "#{scheme_and_domain}{?q}", "templated" => true },
+            "multiple" => [%{ "href" => "#{scheme_and_domain}1" },
+              %{ "href" => "#{scheme_and_domain}2" }]
             },
           "_embedded" =>
-            %{"embedded" => %{"_links" => %{"self" => %{"href" => "http://example.com/embedded"}}}}
+          %{"embedded" => %{"_links" => %{"self" => %{"href" => "#{scheme_and_domain}embedded"}}}}
          }
       )
     end

--- a/test/exhal_test.exs
+++ b/test/exhal_test.exs
@@ -271,16 +271,16 @@ defmodule ExHalTest do
       end
     end
 
-    defp doc(scheme_and_domain \\ "http://example.com/") do
+    defp doc(base_url \\ "http://example.com/") do
       ExHal.Document.from_parsed_hal(ExHal.client,
         %{"_links" =>
-          %{"single" => %{ "href" => scheme_and_domain },
-            "tmpl" => %{ "href" => "#{scheme_and_domain}{?q}", "templated" => true },
-            "multiple" => [%{ "href" => "#{scheme_and_domain}1" },
-              %{ "href" => "#{scheme_and_domain}2" }]
+          %{"single" => %{ "href" => base_url },
+            "tmpl" => %{ "href" => "#{base_url}{?q}", "templated" => true },
+            "multiple" => [%{ "href" => "#{base_url}1" },
+              %{ "href" => "#{base_url}2" }]
             },
           "_embedded" =>
-          %{"embedded" => %{"_links" => %{"self" => %{"href" => "#{scheme_and_domain}embedded"}}}}
+          %{"embedded" => %{"_links" => %{"self" => %{"href" => "#{base_url}embedded"}}}}
          }
       )
     end


### PR DESCRIPTION
Following multiple links could make many requests to multiple servers,
so fetch them concurrently using `Task.async_stream/3`.

Anecdotally, this took a request to follow 40+ remote links from 8-9 seconds down to 2-3 seconds.