### PR TITLE
Change namespace of task not to collide with other release libraries

### DIFF
--- a/lib/mix/tasks/exhal.release.ex
+++ b/lib/mix/tasks/exhal.release.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Release do
+defmodule Mix.Tasks.ExHal.Release do
   @shortdoc "Release the hounds!"
 
   use Mix.Task


### PR DESCRIPTION
# Summary

Depending on the order of dependency compilation in downstream elixir apps, this release module clashes with libraries like `distillery` with the mix task `mix.release`. 

# Potential Solution

In this PR, I added a `ExHal` into the namespace to show that it was specific to this library.