### PR TITLE
Handle Errors when following "next" link when fetching collection

### DIFF
--- a/lib/exhal/collection.ex
+++ b/lib/exhal/collection.ex
@@ -14,7 +14,17 @@ defmodule ExHal.Collection do
       fn -> {:ok, a_doc} end,
       fn follow_result ->
         case follow_result do
-          {:error, _} -> {:halt, follow_result}
+          # End of Pagination
+          {:error, %ExHal.NoSuchLinkError{}} ->
+            {:halt, nil}
+          {:error, %ExHal.NoSuchLinkError{}, _headers} ->
+            {:halt, nil}
+
+          {:error, %ExHal.Error{reason: msg}} ->
+            raise ExHal.CollectionError, message: "Failed to fetch next link due to #{msg}"
+          {:error, %ExHal.Error{reason: msg}, _headers} ->
+            raise ExHal.CollectionError, message: "Failed to fetch next link due to #{msg}"
+
           {:ok, page} -> page |> expand_page
           {:ok, page, %ResponseHeader{}} -> page |> expand_page
         end

--- a/lib/exhal/collection.ex
+++ b/lib/exhal/collection.ex
@@ -7,7 +7,11 @@ defmodule ExHal.Collection do
   alias ExHal.ResponseHeader
 
   @doc """
-  Returns a stream that iterate over the collection represented by `a_doc`.
+  Returns a stream that iterates over the collection represented by `a_doc`.
+  Iteration halts when there is no further `next` link to follow.
+
+  An `ExHal.CollectionError` will be raised to the caller only if an
+  `ExHal.Error` occurs when requesting the next resource.
   """
   def to_stream(a_doc) do
     Stream.resource(

--- a/lib/exhal/collection_error.ex
+++ b/lib/exhal/collection_error.ex
@@ -1,0 +1,3 @@
+defmodule ExHal.CollectionError do
+  defexception [:message]
+end

--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -1,6 +1,4 @@
 defmodule ExHal.Navigation do
-  # client_module() Application.get_env(:exhal, :client, ExHal.Client)
-
   alias ExHal.Link
   alias ExHal.{Error, NoSuchLinkError}
   alias ExHal.ResponseHeader

--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -23,13 +23,14 @@ defmodule ExHal.Navigation do
   @doc """
   Follows all links of a particular rel in a HAL document.
 
-  Returns `[{:ok, %ExHal.Document{...}, %ExHal.ResponseHeader{...}}, {:error, %ExHal.NoSuchLinkError{...}, {:error, %ExHal.Error{...} ...]`
+  Returns `[{:ok, %ExHal.Document{...}, %ExHal.ResponseHeader{...}}, {:error, %ExHal.Error{...} ...]` if link is found;
+  `{:error, %ExHal.NoSuchLinkError{...}` if not
   """
   def follow_links(a_doc, name, opts) when is_map(opts) or is_list(opts) do
     follow_links(
       a_doc,
       name,
-      fn _name -> [{:error, %NoSuchLinkError{reason: "no such link: #{name}"}}] end,
+      fn _name -> {:error, %NoSuchLinkError{reason: "no such link: #{name}"}} end,
       opts
     )
   end

--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -2,7 +2,7 @@ defmodule ExHal.Navigation do
   @client_module Application.get_env(:exhal, :client, ExHal.Client)
 
   alias ExHal.Link
-  alias ExHal.Error
+  alias ExHal.{Error, NoSuchLinkError}
   alias ExHal.ResponseHeader
 
   @doc """
@@ -23,13 +23,13 @@ defmodule ExHal.Navigation do
   @doc """
   Follows all links of a particular rel in a HAL document.
 
-  Returns `[{:ok, %ExHal.Document{...}, %ExHal.ResponseHeader{...}}, {:error, %ExHal.Error{...}, ...]`
+  Returns `[{:ok, %ExHal.Document{...}, %ExHal.ResponseHeader{...}}, {:error, %ExHal.NoSuchLinkError{...}, {:error, %ExHal.Error{...} ...]`
   """
   def follow_links(a_doc, name, opts) when is_map(opts) or is_list(opts) do
     follow_links(
       a_doc,
       name,
-      fn _name -> [{:error, %Error{reason: "no such link: #{name}"}}] end,
+      fn _name -> [{:error, %NoSuchLinkError{reason: "no such link: #{name}"}}] end,
       opts
     )
   end
@@ -105,7 +105,7 @@ defmodule ExHal.Navigation do
   end
 
   @doc """
-  Returns `{:ok, [url1, ...]}` if a matching link is found or `{:error, %ExHal.Error{...}}` if not.
+  Returns `{:ok, [url1, ...]}` if a matching link is found or `{:error, %ExHal.NoSuchLinkError{...}}` if not.
 
   * a_doc - `ExHal.Document` in which to search for links
   * name - the rel of the link of interest
@@ -117,7 +117,7 @@ defmodule ExHal.Navigation do
 
     case ExHal.get_links_lazy(a_doc, name, fn -> :missing end) do
       :missing ->
-        {:error, %Error{reason: "no such link: #{name}"}}
+        {:error, %NoSuchLinkError{reason: "no such link: #{name}"}}
 
       links ->
         {:ok,
@@ -155,7 +155,7 @@ defmodule ExHal.Navigation do
   defp figure_link(a_doc, name, strict?) do
     case ExHal.get_links_lazy(a_doc, name, fn -> :missing end) do
       :missing ->
-        {:error, %Error{reason: "no such link: #{name}"}}
+        {:error, %NoSuchLinkError{reason: "no such link: #{name}"}}
 
       [link] ->
         {:ok, link}

--- a/lib/exhal/navigation.ex
+++ b/lib/exhal/navigation.ex
@@ -1,5 +1,5 @@
 defmodule ExHal.Navigation do
-  @client_module Application.get_env(:exhal, :client, ExHal.Client)
+  # client_module() Application.get_env(:exhal, :client, ExHal.Client)
 
   alias ExHal.Link
   alias ExHal.{Error, NoSuchLinkError}
@@ -54,7 +54,7 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if response is an error if not
   """
   def post(a_doc, name, body, opts \\ %{tmpl_vars: %{}, strict: true}) do
-    update_document(a_doc, name, body, opts, &@client_module.post/4)
+    update_document(a_doc, name, body, opts, &client_module().post/4)
   end
 
   @doc """
@@ -64,7 +64,7 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if response is an error if not
   """
   def put(a_doc, name, body, opts \\ %{tmpl_vars: %{}, strict: true}) do
-    update_document(a_doc, name, body, opts, &@client_module.put/4)
+    update_document(a_doc, name, body, opts, &client_module().put/4)
   end
 
   @doc """
@@ -74,7 +74,7 @@ defmodule ExHal.Navigation do
   `{:error, %ExHal.Error{...}}` if response is an error if not
   """
   def patch(a_doc, name, body, opts \\ %{tmpl_vars: %{}, strict: true}) do
-    update_document(a_doc, name, body, opts, &@client_module.patch/4)
+    update_document(a_doc, name, body, opts, &client_module().patch/4)
   end
 
   defp update_document(a_doc, name, body, opts, fun) do
@@ -194,7 +194,7 @@ defmodule ExHal.Navigation do
         {:ok, link.target, %ResponseHeader{status_code: 200}}
 
       :else ->
-        @client_module.get(client, Link.target_url!(link, tmpl_vars), opts)
+        client_module().get(client, Link.target_url!(link, tmpl_vars), opts)
     end
   end
 
@@ -229,4 +229,6 @@ defmodule ExHal.Navigation do
 
     [timeout: timeout]
   end
+
+  defp client_module(), do: Application.get_env(:exhal, :client, ExHal.Client)
 end

--- a/lib/exhal/no_such_link_error.ex
+++ b/lib/exhal/no_such_link_error.ex
@@ -1,0 +1,3 @@
+defmodule ExHal.NoSuchLinkError do
+  defstruct [:reason]
+end

--- a/test/exhal/collection_test.exs
+++ b/test/exhal/collection_test.exs
@@ -1,7 +1,7 @@
 Code.require_file "../support/request_stubbing.exs", __DIR__
 
 defmodule ExHal.CollectionTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   use RequestStubbing
 
   alias ExHal.Document

--- a/test/exhal/collection_test.exs
+++ b/test/exhal/collection_test.exs
@@ -95,13 +95,11 @@ defmodule ExHal.CollectionTest do
     end
 
     test ".to_stream(multi_page_collection_doc) handles error", %{
-      last_page_collection_url: last_page_collection_url,
-      last_page_collection_hal_str: last_page_collection_hal_str,
       multi_page_collection_doc: multi_page_collection_doc
     } do
 
       ExHal.ClientMock
-      |> expect(:get, fn _client, url, _opts ->
+      |> expect(:get, fn _client, _url, _opts ->
         {:error, %ExHal.Error{reason: :timeout}}
       end)
 

--- a/test/exhal/collection_test.exs
+++ b/test/exhal/collection_test.exs
@@ -78,28 +78,37 @@ defmodule ExHal.CollectionTest do
     end
   end
 
-  test ".to_stream(multi_page_collection_doc) handles error", %{
-    last_page_collection_url: last_page_collection_url,
-    last_page_collection_hal_str: last_page_collection_hal_str,
-    multi_page_collection_doc: multi_page_collection_doc
-  } do
-
-    ExHal.ClientMock
-    |> expect(:get, fn _client, last_page_collection_url, _opts ->
-      {:error, %ExHal.Error{reason: :timeout}}
-    end)
-
-    subject = Collection.to_stream(multi_page_collection_doc)
-
-    assert_raise ExHal.CollectionError, "Failed to fetch next link due to timeout", fn -> Enum.count(subject) end
-  end
-
   test "ExHal.to_stream(sinlge_page_collection_doc) works", ctx do
     assert ExHal.to_stream(ctx[:single_page_collection_doc]) |> is_a_stream
   end
 
   test "ExHal.to_stream(truly_empty_collection_doc) works", %{truly_empty_collection_doc: doc} do
     assert ExHal.to_stream(doc) |> is_a_stream
+  end
+
+  describe "Non Hal Responses" do
+    setup do
+      Application.put_env(:exhal, :client, ExHal.ClientMock)
+      on_exit fn ->
+        Application.put_env(:exhal, :client, ExHal.Client)
+      end
+    end
+
+    test ".to_stream(multi_page_collection_doc) handles error", %{
+      last_page_collection_url: last_page_collection_url,
+      last_page_collection_hal_str: last_page_collection_hal_str,
+      multi_page_collection_doc: multi_page_collection_doc
+    } do
+
+      ExHal.ClientMock
+      |> expect(:get, fn _client, url, _opts ->
+        {:error, %ExHal.Error{reason: :timeout}}
+      end)
+
+      subject = Collection.to_stream(multi_page_collection_doc)
+
+      assert_raise ExHal.CollectionError, "Failed to fetch next link due to timeout", fn -> Enum.count(subject) end
+    end
   end
 
 

--- a/test/exhal/form_test.exs
+++ b/test/exhal/form_test.exs
@@ -9,6 +9,13 @@ defmodule ExHal.FormTest do
   import Mox
   setup :verify_on_exit!
 
+  setup do
+    Application.put_env(:exhal, :client, ExHal.ClientMock)
+    on_exit fn ->
+      Application.put_env(:exhal, :client, ExHal.Client)
+    end
+  end
+
   doctest ExHal.Form
 
   describe ".from_forms_entry/1" do

--- a/test/exhal/navigation_test.exs
+++ b/test/exhal/navigation_test.exs
@@ -22,6 +22,20 @@ defmodule ExHal.NavigationTest do
     assert {:ok, "http://example.com/e"} = ExHal.url(target)
   end
 
+  test ".follow_links w/ embedded link", %{doc: doc} do
+    stub_request "get", url: "~r/http:\/\/example.com\/[12]/", resp_body: hal_str("") do
+      Navigation.follow_links(doc, "multiple")
+      |> Enum.each(fn resp ->
+        assert {:ok, target = %Document{}, %ResponseHeader{status_code: 200}} = resp
+        assert {:ok, _} = ExHal.url(target)
+      end)
+    end
+  end
+
+  test ".follow_links w/ non-existent rel", %{doc: doc} do
+    assert {:error, %ExHal.NoSuchLinkError{}} = Navigation.follow_links(doc, "absent")
+  end
+
   test ".post", %{doc: doc} do
     new_thing_hal = hal_str("http://example.com/new-thing")
 

--- a/test/exhal/navigation_test.exs
+++ b/test/exhal/navigation_test.exs
@@ -4,7 +4,7 @@ defmodule ExHal.NavigationTest do
   use ExUnit.Case, async: false
   use RequestStubbing
 
-  alias ExHal.{Navigation,Document,Error,ResponseHeader}
+  alias ExHal.{Navigation,Document,Error,NoSuchLinkError,ResponseHeader}
 
   test ".follow_link", %{doc: doc} do
     thing_hal = hal_str("http://example.com/thing")
@@ -72,7 +72,7 @@ defmodule ExHal.NavigationTest do
 
     assert {:error, %Error{}} = Navigation.link_target(doc, "multiple", strict: true)
 
-    assert {:error, %Error{}} = Navigation.link_target(doc, "nonexistent")
+    assert {:error, %NoSuchLinkError{}} = Navigation.link_target(doc, "nonexistent")
   end
 
   # Background

--- a/test/exhal/transcoder_test.exs
+++ b/test/exhal/transcoder_test.exs
@@ -129,8 +129,8 @@ defmodule ExHal.TranscoderTest do
     encoded = MyEmptyLinkTranscoder.encode!(%{present: "http://example.com/present",
                                               present_but_nil: nil})
 
-    assert {:error, %ExHal.Error{reason: "no such link: absent"}} == ExHal.link_target(encoded, "absent")
-    assert {:error, %ExHal.Error{reason: "no such link: present_but_nil"}} == ExHal.link_target(encoded, "present_but_nil")
+    assert {:error, %ExHal.NoSuchLinkError{reason: "no such link: absent"}} == ExHal.link_target(encoded, "absent")
+    assert {:error, %ExHal.NoSuchLinkError{reason: "no such link: present_but_nil"}} == ExHal.link_target(encoded, "present_but_nil")
   end
 
   test "don't try to extract links from document that has no links" do

--- a/test/exhal_test.exs
+++ b/test/exhal_test.exs
@@ -216,7 +216,7 @@ defmodule ExHalTest do
     end
 
     test ".follow_links w/ non-existent rel" do
-      assert [{:error, %ExHal.NoSuchLinkError{}}] = ExHal.follow_links(doc(), "absent")
+      assert {:error, %ExHal.NoSuchLinkError{}} = ExHal.follow_links(doc(), "absent")
     end
 
     test ".follow_links w/ multiple links" do

--- a/test/exhal_test.exs
+++ b/test/exhal_test.exs
@@ -167,7 +167,7 @@ defmodule ExHalTest do
     end
 
     test ".follow_link w/ non-existent rel" do
-      assert {:error, %ExHal.Error{}} = ExHal.follow_link(doc(), "absent")
+      assert {:error, %ExHal.NoSuchLinkError{}} = ExHal.follow_link(doc(), "absent")
     end
 
     test ".follow_link w/ malformed URL" do
@@ -216,7 +216,7 @@ defmodule ExHalTest do
     end
 
     test ".follow_links w/ non-existent rel" do
-      assert [{:error, %ExHal.Error{}}] = ExHal.follow_links(doc(), "absent")
+      assert [{:error, %ExHal.NoSuchLinkError{}}] = ExHal.follow_links(doc(), "absent")
     end
 
     test ".follow_links w/ multiple links" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,5 +3,3 @@ Application.ensure_all_started(:mox)
 Application.ensure_all_started(:stream_data)
 
 Mox.defmock(ExHal.ClientMock, for: ExHal.Client)
-
-Application.put_env(:exhal, :client, ExHal.ClientMock)


### PR DESCRIPTION
While following the next link it times out. Rather than return a partial collection it should raise an error. 

This PR will: 
* Create a new Error type NoSuchLinkError
* When an unsuccessful response is returned raise CollectionError

Example Stacktrace: 
```
** (ExHal.CollectionError) Failed to fetch next link due to timeout
    lib/exhal/collection.ex:24: anonymous fn/1 in ExHal.Collection.to_stream/1
    (elixir) lib/stream.ex:1377: Stream.do_resource/5
    (elixir) lib/stream.ex:1553: Enumerable.Stream.do_each/4
    (elixir) lib/enum.ex:2979: Enum.map/2
```